### PR TITLE
fix: resolve annotated tags to their underlying commit

### DIFF
--- a/fuse/tags.go
+++ b/fuse/tags.go
@@ -45,12 +45,16 @@ func (f *TagsDir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 
 func (f *TagsDir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 	refName := plumbing.ReferenceName("refs/tags/" + name)
-	// we need to resolve the reference in case it's symbolic
-	// TODO: this doesn't seem to work for the tags in git's own repo
 	ref, err := f.repo.Reference(refName, true)
 	if err != nil {
 		return nil, fuse.ENOENT
 	}
-	id := ref.Hash().String()
-	return &SymLink{"../" + commitPath(id)}, nil
+	hash := ref.Hash()
+	// annotated tags point to a tag object, not a commit — peel to the commit
+	if tagObj, err := f.repo.TagObject(hash); err == nil {
+		if commit, err := tagObj.Commit(); err == nil {
+			hash = commit.Hash
+		}
+	}
+	return &SymLink{"../" + commitPath(hash.String())}, nil
 }


### PR DESCRIPTION
## Problem

  Trying to `cd` into a directory under `tags/` that corresponds to  an annotated
  tag fails with "No such file or directory", and the server logs:

```bash
      error: can't get commit object: object not found
```

Annotated tags (created with `git tag -a`) don't point directly to   a commit.
They point to a tag object, which in turn points to the commit. 
The previous code passed the tag object's hash directly to `commitPath()`, so
  the FUSE
  filesystem tried to look up a commit at that hash and failed.

  Lightweight tags (created with `git tag`) were unaffected since
  they point
  directly to a commit.

  ## Fix

  After resolving the reference, peel through any tag object to reach
   the
  underlying commit using go-git's `TagObject()` + `Commit()`:

  ```go
  if tagObj, err := f.repo.TagObject(hash); err == nil {
      if commit, err := tagObj.Commit(); err == nil {
          hash = commit.Hash
      }
      if commit, err := tagObj.Commit(); err == nil {
          hash = commit.Hash
      }
  }
```

  Lightweight tags are unaffected — TagObject() returns an error for them so
  the hash passes through unchanged.

